### PR TITLE
Peg version to 2.11 to bring back rack dependency

### DIFF
--- a/logstash-input-http.gemspec
+++ b/logstash-input-http.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud'
-  s.add_runtime_dependency 'puma'
+  s.add_runtime_dependency 'puma', '~> 2.11.3'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-json'


### PR DESCRIPTION
This plugin has a dependency on rack framework and is also failing numerous tests. https://github.com/jsvd/logstash-input-http/commit/f433f68539e3836ac99f432ba6718e4a231d6008