### PR TITLE
Missing require for base64

### DIFF
--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -5,6 +5,7 @@ require "stud/interval"
 require "socket" # for Socket.gethostname
 require "puma/server"
 require "puma/minissl"
+require "base64"
 
 class Puma::Server
   # ensure this method doesn't mess up our vanilla request


### PR DESCRIPTION
As reported in #17, http basic auth is unusable due to this missing required.
This is not catched by the specs because base64 is transitively loaded when requiring ftw (used as a dev dependency)