### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -144,14 +144,12 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
   end
 
   public
-  def teardown
-    if @server
-      @server.stop(true)
-      begin
-        @server.binder.close if @server.binder
-      rescue IOError
-      end
-    end
+  def stop
+    return unless @server
+    @server.stop(true)
+    @server.binder.close if @server.binder
+  rescue IOError
+    # do nothing
   end
 
 end # class LogStash::Inputs::Http

--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -15,7 +15,11 @@ describe LogStash::Inputs::Http do
   let(:port) { rand(5000) + 1025 }
 
   after :each do
-    subject.teardown
+    subject.stop
+  end
+
+  it_behaves_like "an interruptible input plugin" do
+    let(:config) { { "port" => port } }
   end
 
   context "with default codec" do


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3895

resolves #32