### PR TITLE
Allow custom HTTP responses and message to be set in the config file

### DIFF
--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -106,7 +106,7 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
   config :response_deflate_status, :validate => :number, :default => 400
 
   # http response message for decompression error
-  config :response_deflate_message, :validate => :string, :default => 'failed to decompress body'
+  config :response_deflate_message, :validate => :string, :default => 'Failed to decompress body'
 
   # useless headers puma adds to the requests
   # mostly due to rack compliance

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -102,12 +102,6 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
   # http response message for general error
   config :response_err_message, :validate => :string, :default => 'internal error'
 
-  # http response code for decompression error
-  config :response_deflate_status, :validate => :number, :default => 400
-
-  # http response message for decompression error
-  config :response_deflate_message, :validate => :string, :default => 'Failed to decompress body'
-
   # useless headers puma adds to the requests
   # mostly due to rack compliance
   REJECTED_HEADERS = ["puma.socket", "rack.hijack?", "rack.hijack", "rack.url_scheme", "rack.after_reply", "rack.version", "rack.errors", "rack.multithread", "rack.multiprocess", "rack.run_once", "SCRIPT_NAME", "QUERY_STRING", "SERVER_PROTOCOL", "SERVER_SOFTWARE", "GATEWAY_INTERFACE"]

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -88,6 +88,26 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
   # specify a custom set of response headers
   config :response_headers, :validate => :hash, :default => { 'Content-Type' => 'text/plain' }
 
+  # HTTP Response Configurations
+  #
+  # http response code for success
+  config :response_ok_status, :validate => :number, :default => 200
+
+  # http response message for success
+  config :response_ok_message, :validate => :string, :default => 'ok'
+
+  # http response code for general error
+  config :response_err_status, :validate => :number, :default => 500
+
+  # http response message for general error
+  config :response_err_message, :validate => :string, :default => 'internal error'
+
+  # http response code for decompression error
+  config :response_deflate_status, :validate => :number, :default => 400
+
+  # http response message for decompression error
+  config :response_deflate_message, :validate => :string, :default => 'failed to decompress body'
+
   # useless headers puma adds to the requests
   # mostly due to rack compliance
   REJECTED_HEADERS = ["puma.socket", "rack.hijack?", "rack.hijack", "rack.url_scheme", "rack.after_reply", "rack.version", "rack.errors", "rack.multithread", "rack.multiprocess", "rack.run_once", "SCRIPT_NAME", "QUERY_STRING", "SERVER_PROTOCOL", "SERVER_SOFTWARE", "GATEWAY_INTERFACE"]
@@ -143,10 +163,10 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
           decorate(event)
           queue << event
         end
-        ['200', @response_headers, ['ok']]
+        [@response_ok_status, @response_headers, [@response_ok_message]]
       rescue => e
         @logger.error("unable to process event #{req.inspect}. exception => #{e.inspect}")
-        ['500', @response_headers, ['internal error']]
+        [@response_err_status, @response_headers, [@response_err_message]]
       end
     end
 

--- a/lib/logstash/util/http_compressed_requests.rb
+++ b/lib/logstash/util/http_compressed_requests.rb
@@ -16,7 +16,7 @@ class CompressedRequests
       begin
         extracted = decode(env['rack.input'], env['HTTP_CONTENT_ENCODING'])
       rescue Zlib::Error
-        return [@response_deflate_status, {'Content-Type' => 'text/plain'}, [@response_deflate_message]]
+        return [400, {'Content-Type' => 'text/plain'}, ["Failed to decompress body"]]
       end
 
       env.delete('HTTP_CONTENT_ENCODING')

--- a/lib/logstash/util/http_compressed_requests.rb
+++ b/lib/logstash/util/http_compressed_requests.rb
@@ -16,7 +16,7 @@ class CompressedRequests
       begin
         extracted = decode(env['rack.input'], env['HTTP_CONTENT_ENCODING'])
       rescue Zlib::Error
-        return [400, {'Content-Type' => 'text/plain'}, ["Failed to decompress body"]]
+        return [@response_deflate_status, @response_headers, [@response_deflate_message]]
       end
 
       env.delete('HTTP_CONTENT_ENCODING')

--- a/lib/logstash/util/http_compressed_requests.rb
+++ b/lib/logstash/util/http_compressed_requests.rb
@@ -16,7 +16,7 @@ class CompressedRequests
       begin
         extracted = decode(env['rack.input'], env['HTTP_CONTENT_ENCODING'])
       rescue Zlib::Error
-        return [@response_deflate_status, @response_headers, [@response_deflate_message]]
+        return [@response_deflate_status, {'Content-Type' => 'text/plain'}, [@response_deflate_message]]
       end
 
       env.delete('HTTP_CONTENT_ENCODING')


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
This can be very useful if the input plugin is running behind a proxy or application firewall service.
