### PR TITLE
Improve error logging to include full exception details.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+## 3.0.4
+  - Improve error logging to log more details, including stack trace, for true bugs.
+    This makes debugging broken codecs much easier.
 ## 3.0.3
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
-
 ## 3.0.2
   - Use a new class as redefined Puma::Server class as we need to mock one method and only need it for this plugin, but not for all parts using puma in logstash.Fixes https://github.com/logstash-plugins/logstash-input-http/issues/51.
 ## 3.0.1

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -145,7 +145,13 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
         end
         ['200', @response_headers, ['ok']]
       rescue => e
-        @logger.error("unable to process event #{req.inspect}. exception => #{e.inspect}")
+        @logger.error(
+          "unable to process event.", 
+          :request => req,
+          :message => e.message,
+          :class => e.class.name,
+          :backtrace => e.backtrace
+        )
         ['500', @response_headers, ['internal error']]
       end
     end

--- a/logstash-input-http.gemspec
+++ b/logstash-input-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-http'
-  s.version         = '3.0.3'
+  s.version         = '3.0.4'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Logstash Input plugin that receives HTTP requests"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Errors in codecs should log a full backtrace since those are unexpected.
This came up dealing with
https://github.com/logstash-plugins/logstash-codec-nmap/issues/13
