### PR TITLE
#60 Lock around Codec to Make it Thread-Safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.lock
 Gemfile.bak
 .bundle
 vendor
+.idea


### PR DESCRIPTION
Fixes concurrency issue for #60 

Same as we had with Kafka in https://github.com/logstash-plugins/logstash-input-kafka/commit/83fd74a2e5aa810efe1a463c7bdbab032d67a0b8 in principle.

In practice, this is a little harder, because the threading is handled by Rack so we cannot clone the codec once per thread beforehand (at least I don't know an API to do that, if you know one please tell me and I can create a faster fix).
The way I did it now was to simply enforce single threaded decoding. Not optimal, but should be very close to the current performance characteristics and work bug-free.