### PR TITLE
Prevent file descriptor leaks by limiting the max number of connections with un-returned responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.8
+  - In the event that all webserver threads are busy this plugin will now return a 429, busy, error.
+
 ## 3.0.7
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,6 +31,19 @@ This input can also be used to receive webhook requests to integrate with other 
 and applications. By taking advantage of the vast plugin ecosystem available in Logstash
 you can trigger actionable events right from your application.
 
+==== Blocking Behavior
+
+The HTTP protocol doesn't deal well with long running requests. This plugin will either return 
+a 429 (busy) error when Logstash is backlogged, or it will time out the request. 
+
+If a 429 error is encountered clients should sleep, backing off exponentially with some random 
+jitter, then retry their request.
+
+This plugin will block if the Logstash queue is blocked and there are available HTTP input threads.
+This will cause most HTTP clients to time out. Sent events will still be processed in this case. This
+behavior is not optimal and will be changed in a future release. In the future, this plugin will always 
+return a 429 if the queue is busy, and will not time out in the event of a busy queue. 
+
 ==== Security
 This plugin supports standard HTTP basic authentication headers to identify the requester.
 You can pass in a username, password combination while sending data to this input

--- a/logstash-input-http.gemspec
+++ b/logstash-input-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-http'
-  s.version         = '3.0.7'
+  s.version         = '3.0.8'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Receives events over HTTP or HTTPS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This plugin currently leaks file descriptors. This patch prevents that by changing the behavior such that when all but one webserver threads are occupied a 429 error will be immediately returned. This means that in the event of a blocked queue we will have one thread available to reject all new attempts to write.

As a side benefit, it made sense to fix the concurrency bottleneck around codec so long as we needed the write slots concept by duplicating the codec hash through the write slots

This isn't perfect, we need queue write timeouts to do this well, but it's a decent short term fix.