### PR TITLE
flush codec after decode

### DIFF
--- a/logstash-input-http.gemspec
+++ b/logstash-input-http.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-json'
+  s.add_development_dependency 'logstash-codec-line'
   s.add_development_dependency 'ftw'
 end


### PR DESCRIPTION
This PR depends on logstash-plugins/logstash-codec-json_lines#35

The http input only accepts self-contained payload for each request and multipart is not supported. Because of this, we should always flush the codec after each request & codec decode calls to avoid situations where a delimited content missing a final delimiter, for example, would linger in the codec. 

This is similar in nature to the discussion in https://github.com/elastic/logstash/issues/8830#issuecomment-351472669

Spec added to test this condition. Otherwise codec support is also well tested in the current spec.
