### PR TITLE
move most message handling code to java

### DIFF
--- a/src/main/java/org/logstash/plugins/inputs/http/IMessageHandler.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/IMessageHandler.java
@@ -1,7 +1,6 @@
 package org.logstash.plugins.inputs.http;
 
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
+import java.util.Map;
 
 /**
  * Created by joaoduarte on 16/10/2017.
@@ -12,13 +11,27 @@ public interface IMessageHandler {
      * and should be executed in the ruby world.
      *
      * @param remoteAddress
-     * @param message
+     * @param headers
+     * @param body
      */
-    FullHttpResponse onNewMessage(String remoteAddress, FullHttpRequest message);
+    boolean onNewMessage(String remoteAddress, Map<String,String> headers, String body);
+
+    /**
+     *
+     * @param token
+     * @return
+     */
+    boolean validatesToken(String token);
 
     /**
      *
      * @return copy of the message handler
      */
     IMessageHandler copy();
+
+    /**
+     *
+     * @return
+     */
+    Map<String, String> responseHeaders();
 }

--- a/src/main/java/org/logstash/plugins/inputs/http/MessageHandler.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/MessageHandler.java
@@ -1,9 +1,9 @@
 package org.logstash.plugins.inputs.http;
 
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
 
 /**
  * This class is implemented in ruby in `lib/logstash/inputs/http/message_listener`,
@@ -19,15 +19,26 @@ public class MessageHandler implements IMessageHandler {
      * and should be executed in the ruby world.
      *
      * @param remoteAddress
-     * @param message
+     * @param headers
+     * @param body
      */
-    public FullHttpResponse onNewMessage(String remoteAddress, FullHttpRequest message) {
+    public boolean onNewMessage(String remoteAddress, Map<String,String> headers, String body) {
         logger.debug("onNewMessage");
-        return null;
+        return false;
     }
 
     public MessageHandler copy() {
         logger.debug("copy");
         return new MessageHandler();
+    }
+
+    public boolean validatesToken(String token) {
+        logger.debug("validatesToken");
+        return false;
+    }
+
+    public Map<String, String> responseHeaders() {
+        logger.debug("responseHeaders");
+        return null;
     }
 }

--- a/src/main/java/org/logstash/plugins/inputs/http/MessageProcessor.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/MessageProcessor.java
@@ -60,7 +60,7 @@ public class MessageProcessor implements RejectableRunnable {
 
     private FullHttpResponse processMessage() {
         final Map<String, String> formattedHeaders = formatHeaders(req.headers());
-        final String body = readBytes(req.content());
+        final String body = req.content().toString(charset);
         if (messageHandler.onNewMessage(remoteAddress, formattedHeaders, body)) {
             return generateResponse(messageHandler.responseHeaders());
         } else {
@@ -91,13 +91,6 @@ public class MessageProcessor implements RejectableRunnable {
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
 
         return response;
-    }
-
-
-    private String readBytes(ByteBuf buf) {
-        final byte[] bytes = new byte[buf.readableBytes()];
-        buf.getBytes(0, bytes);
-        return new String(bytes, charset);
     }
 
     private Map<String,String>formatHeaders(HttpHeaders headers) {

--- a/src/main/java/org/logstash/plugins/inputs/http/MessageProcessor.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/MessageProcessor.java
@@ -1,18 +1,28 @@
 package org.logstash.plugins.inputs.http;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.logstash.plugins.inputs.http.util.RejectableRunnable;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MessageProcessor implements RejectableRunnable {
     private final ChannelHandlerContext ctx;
     private final FullHttpRequest req;
     private final String remoteAddress;
     private final IMessageHandler messageHandler;
+    private static final Charset charset = Charset.forName("UTF-8");
 
     public MessageProcessor(ChannelHandlerContext ctx, FullHttpRequest req, String remoteAddress,
                             IMessageHandler messageHandler) {
@@ -24,8 +34,7 @@ public class MessageProcessor implements RejectableRunnable {
 
     public void onRejection() {
         try {
-            final DefaultHttpResponse response = new DefaultHttpResponse(req.protocolVersion(), HttpResponseStatus.TOO_MANY_REQUESTS);
-            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+            final FullHttpResponse response = generateFailedResponse(HttpResponseStatus.TOO_MANY_REQUESTS);
             ctx.writeAndFlush(response);
         } finally {
             req.release();
@@ -35,11 +44,72 @@ public class MessageProcessor implements RejectableRunnable {
     @Override
     public void run() {
         try {
-            final FullHttpResponse response = messageHandler.onNewMessage(remoteAddress, req);
+            final HttpResponse response;
+            final String token = req.headers().get(HttpHeaderNames.AUTHORIZATION);
+            if (messageHandler.validatesToken(token)) {
+                final Map<String, String> formattedHeaders = formatHeaders(req.headers());
+                final String body = readBytes(req.content());
+                if (messageHandler.onNewMessage(remoteAddress, formattedHeaders, body)) {
+                    response = generateResponse(messageHandler.responseHeaders());
+                } else {
+                    response = generateFailedResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                }
+            } else {
+                response = generateFailedResponse(HttpResponseStatus.UNAUTHORIZED);
+            }
             ctx.writeAndFlush(response);
         } finally {
             req.release();
         }
+    }
+
+    private FullHttpResponse generateFailedResponse(HttpResponseStatus status) {
+        final FullHttpResponse response = new DefaultFullHttpResponse(req.protocolVersion(), status);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        return response;
+    }
+
+    private FullHttpResponse generateResponse(Map<String, String> stringHeaders) {
+
+        final ByteBuf payload = Unpooled.wrappedBuffer("ok".getBytes(charset));
+        final FullHttpResponse response = new DefaultFullHttpResponse(
+                req.protocolVersion(),
+                HttpResponseStatus.OK,
+                payload);
+
+        final DefaultHttpHeaders headers = new DefaultHttpHeaders();
+        for(String key : stringHeaders.keySet()) {
+            headers.set(key, stringHeaders.get(key));
+        }
+        response.headers().set(headers);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, payload.readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
+
+        return response;
+    }
+
+
+    private String readBytes(ByteBuf buf) {
+        final byte[] bytes = new byte[buf.readableBytes()];
+        buf.getBytes(0, bytes);
+        return new String(bytes, charset);
+    }
+
+    private Map<String,String>formatHeaders(HttpHeaders headers) {
+        final HashMap<String, String> formattedHeaders = new HashMap<>();
+        for (Map.Entry<String, String> header : headers) {
+            String key = header.getKey();
+            key = key.toLowerCase();
+            key = key.replace('-', '_');
+            formattedHeaders.put(key, header.getValue());
+        }
+        formattedHeaders.put("http_accept", formattedHeaders.remove("accept"));
+        formattedHeaders.put("http_host", formattedHeaders.remove("host"));
+        formattedHeaders.put("http_user_agent", formattedHeaders.remove("user_agent"));
+        formattedHeaders.put("request_method", req.method().name());
+        formattedHeaders.put("request_path", req.uri());
+        formattedHeaders.put("http_version", req.protocolVersion().text());
+        return formattedHeaders;
     }
 }
 

--- a/src/main/java/org/logstash/plugins/inputs/http/NettyHttpServer.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/NettyHttpServer.java
@@ -6,6 +6,8 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
 import org.logstash.plugins.inputs.http.util.CustomRejectedExecutionHandler;
 import org.logstash.plugins.inputs.http.util.SslBuilder;
 


### PR DESCRIPTION
move the creation of most objects to java land
essentially the ruby side only invokes the codecs

performance bump of 15-20% on a simple noop pipeline ( `bin/logstash -e "input { http {} } output {}"`)