### PR TITLE
Enforce content-type header parsing

### DIFF
--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -160,6 +160,7 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
     http_full_request.headers.each do |header|
       headers[header.key.downcase.tr('-', '_')] = header.value
     end
+
     headers["request_method"] = http_full_request.getMethod.name
     headers["request_path"] = http_full_request.getUri
     headers["http_version"] = http_full_request.getProtocolVersion.text

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -4,6 +4,8 @@ require "logstash/namespace"
 require "stud/interval"
 require "logstash-input-http_jars"
 
+java_import "io.netty.handler.codec.http.HttpUtil"
+
 # Using this input you can receive single or multiline events over http(s).
 # Applications can send a HTTP POST request with a body to the endpoint started by this
 # input and Logstash will convert it into an event for subsequent processing. Users 
@@ -164,7 +166,7 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
     headers["http_accept"] = headers.delete("accept")
     headers["http_host"] = headers.delete("host")
     headers["http_user_agent"] = headers.delete("user_agent")
-    codec = additional_codecs.fetch(headers["content_type"], default_codec)
+    codec = additional_codecs.fetch(HttpUtil.getMimeType(http_full_request), default_codec)
     codec.decode(body) { |event| push_decoded_event(headers, remote_address, event) }
     codec.flush { |event| push_decoded_event(headers, remote_address, event) }
     [200, @response_headers, 'ok']

--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -190,6 +190,19 @@ describe LogStash::Inputs::Http do
         expect(event.get("message")).to eq(body)
       end
     end
+    
+    context "when receiving a content-type with a charset" do
+      subject { LogStash::Inputs::Http.new("port" => port,
+                                           "additional_codecs" => { "application/json" => "plain" }) }
+      it "should decode the message accordingly" do
+        body = { "message" => "Hello" }.to_json
+        client.post("http://127.0.0.1:#{port}/meh.json",
+                    :headers => { "content-type" => "application/json; charset=utf-8" },
+                      :body => body).call
+        event = logstash_queue.pop
+        expect(event.get("message")).to eq(body)
+      end
+    end
 
     context "when using custom headers" do
       let(:custom_headers) { { 'access-control-allow-origin' => '*' } }


### PR DESCRIPTION
Use Netty HttpUtil getMimeType method to get the content-type, instead of the raw HTTP header.

This should fix: https://github.com/logstash-plugins/logstash-input-http/issues/35