### PR TITLE
Upgrade log4j-api to 2.8.2 as CVE-2017-5645

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,11 @@ repositories {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.apache.logging.log4j:log4j-core:2.6.2'
+    testCompile 'org.apache.logging.log4j:log4j-core:2.8.2'
 
     compile 'io.netty:netty-all:4.1.18.Final'
     compile 'io.netty:netty-tcnative-boringssl-static:2.0.7.Final'
-    compile 'org.apache.logging.log4j:log4j-api:2.6.2'
+    compile 'org.apache.logging.log4j:log4j-api:2.8.2'
 
 }
 


### PR DESCRIPTION
Vulnerability CVE-2017-5645 requires Apache Log4j 2.x upgraded to version to or after 2.8.2
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5645
In Apache Log4j 2.x before 2.8.2, when using the TCP socket server or UDP socket server to receive serialized log events from another application, a specially crafted binary payload can be sent that, when deserialized, can execute arbitrary code.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
