### PR TITLE
Update netty and tcnative dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.apache.logging.log4j:log4j-core:2.11.1'
 
-    compile 'io.netty:netty-all:4.1.30.Final'
-    compile 'io.netty:netty-tcnative-boringssl-static:2.0.12.Final'
+    compile 'io.netty:netty-all:4.1.43.Final'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.27.Final'
     compile 'org.apache.logging.log4j:log4j-api:2.11.1'
 
 }

--- a/src/main/java/org/logstash/plugins/inputs/http/util/SslSimpleBuilder.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/SslSimpleBuilder.java
@@ -29,14 +29,10 @@ public class SslSimpleBuilder implements SslBuilder {
     This list require the OpenSSl engine for netty.
     */
     public final static String[] DEFAULT_CIPHERS = new String[] {
-            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
     };
 
     private String[] ciphers = DEFAULT_CIPHERS;


### PR DESCRIPTION
NOTE: this PR removes all the _CBC_ ciphers as they have been deemed insecure and in newer versions of tcnative-boringssl-static they are not available anymore.

Due to security nature of this change we won't consider it a breaking change. 