### PR TITLE
experiment in dropping tcnative for jdks ssl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     testCompile 'org.apache.logging.log4j:log4j-core:2.11.1'
 
     compile 'io.netty:netty-all:4.1.43.Final'
-    compile 'io.netty:netty-tcnative-boringssl-static:2.0.27.Final'
     compile 'org.apache.logging.log4j:log4j-api:2.11.1'
 
 }


### PR DESCRIPTION
This is an experiment to demonstrate dropping the tcnative dependency for jdk's ssl.

The reason for this removal is that tcnative is sometimes dependent on particular internals of netty, thereby creating (non-explicit) versioning constraints. Also, it is hard to understand the changes that go into tcnative, and coupling that with the removal of CBC ciphers leads to considering not having to rely on this external library for TLS/SSL.