### PR TITLE
Add example of additional_codecs setting

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -107,6 +107,16 @@ Apply specific codecs for specific content types.
 The default codec will be applied only after this list is checked
 and no codec for the request's content-type is found
 
+For example, to process a http request using _bulk you could use the following which would process the request using the json codec according to the Content-Type setting and, additionally, use the es_bulk codec:
+[source,ruby]
+    http {
+    additional_codecs => {"application/json"=>"es_bulk"}
+    response_headers => {
+      "Content-Type" => "application/json"
+                        }
+          }
+           }
+
 [id="plugins-{type}s-{plugin}-cipher_suites"]
 ===== `cipher_suites` 
 


### PR DESCRIPTION
Add an example using the additional_codecs setting to clarify what the document is stating about using two codecs and reinforce the codec setting's tie back to the Content-Type setting

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
