### PR TITLE
ensure execution_context is propagated to additional_codecs

### DIFF
--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -140,7 +140,7 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
     @codecs = Hash.new
 
     @additional_codecs.each do |content_type, codec|
-      @codecs[content_type] = LogStash::Plugin.lookup("codec", codec).new
+      @codecs[content_type] = initialize_codec(codec)
     end
 
     require "logstash/inputs/http/message_handler"
@@ -331,6 +331,13 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
       error_details[:cause][:backtrace] = cause.backtrace if trace || @logger.debug?
     end
     error_details
+  end
+
+  def initialize_codec(codec_name)
+    codec_klass = LogStash::Plugin.lookup("codec", codec_name)
+    return codec_klass.new unless defined?(::LogStash::Plugins::Contextualizer)
+
+    ::LogStash::Plugins::Contextualizer.initialize_plugin(execution_context, codec_klass)
   end
 
 end # class LogStash::Inputs::Http


### PR DESCRIPTION
This solves the issue where a pipeline is started with `pipeline.ecs_compatibility` set to a value other than the default, and the `additional_codecs` instantiated by this plugin do not respect the pipeline setting.

It does so by reaching into Logstash internals IFF the necessary `::LogStash::Plugins::Contextualizer` is present.

In the long-run, I would prefer to provide a plugin factory from Logstash core (see: https://github.com/logstash-plugins/logstash-mixin-plugin_factory_support/pull/1), but this solves the immediate need for this particular plugin.