### PR TITLE
Add header medatata flag

### DIFF
--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -189,9 +189,15 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
   end
 
   def push_decoded_event(headers, remote_address, event)
-    add_ecs_fields(headers, event)
-    event.set(@request_headers_target_field, headers)
-    event.set(@remote_host_target_field, remote_address)
+    skip_enrichment = event.get("skip_enrichment")
+    if !skip_enrichment
+      add_ecs_fields(headers, event)
+      event.set(@request_headers_target_field, headers)
+      event.set(@remote_host_target_field, remote_address)
+    end
+    event_hash = event.to_hash
+    event_hash.delete("skip_enrichment")
+    event = LogStash::Event.new(event_hash)
     decorate(event)
     @queue << event
   end

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -195,6 +195,10 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
       add_ecs_fields(headers, event)
       event.set(@request_headers_target_field, headers)
       event.set(@remote_host_target_field, remote_address)
+    else
+      event_hash = event.to_hash
+      event_hash.delete("event")
+      event = LogStash::Event::new(event_hash)
     end
     decorate(event)
     @queue << event

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -115,6 +115,8 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
 
   config :response_code, :validate => [200, 201, 202, 204], :default => 200
 
+  config :add_header_metadata, :validate => :boolean, :required => false, :default => true
+
   # Deprecated options
 
   # The JKS keystore to validate the client's certificates
@@ -189,15 +191,11 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
   end
 
   def push_decoded_event(headers, remote_address, event)
-    skip_enrichment = event.get("skip_enrichment")
-    if !skip_enrichment
+    if add_header_metadata
       add_ecs_fields(headers, event)
       event.set(@request_headers_target_field, headers)
       event.set(@remote_host_target_field, remote_address)
     end
-    event_hash = event.to_hash
-    event_hash.delete("skip_enrichment")
-    event = LogStash::Event.new(event_hash)
     decorate(event)
     @queue << event
   end

--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -413,7 +413,7 @@ describe LogStash::Inputs::Http do
           let(:content_length_field) { ecs_select[disabled: "[headers][content_length]", v1: "[http][request][body][bytes]"] }
           let(:content_type_field) { ecs_select[disabled: "[headers][content_type]", v1: "[http][request][mime_type]"] }
 
-          before :each do
+          before :each do 
             allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
             setup_server_client
           end
@@ -490,15 +490,19 @@ describe LogStash::Inputs::Http do
       end
     end
     context "disabled" do
+      before :each do
+        setup_server_client
+      end
+      subject { LogStash::Inputs::Http.new(config.merge("port" => port)) }
+      let(:config) { { "add_header_metadata" => false } }
       it "metadata is not added" do
-        let(:config) { { "add_metadata_header" => false} }
-        client.post("http://127.0.0.1:#{port}/meh.json",
+        client.post("http://localhost:#{port}/meh.json",
                     :headers => { "content-type" => "text/plain" },
                     :body => "hello").call
         event = logstash_queue.pop
         event_hash = event.to_hash
         expect(event.get("message")).to eq("hello")
-        expect(event_hash.keys).to eq([:@timesamp, :@version, :message])
+        expect(event_hash.keys).to match_array(["@version", "@timestamp", "message"])
       end
     end
   end

--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -499,6 +499,7 @@ describe LogStash::Inputs::Http do
         event_hash = event.to_hash
         expect(event.get("message")).to eq("hello")
         expect(event_hash.keys).to eq([:@timesamp, :@version, :message])
+      end
     end
   end
 


### PR DESCRIPTION
Add a new logstash configuration parameter to avoid adding header metadata and ```event.original``` to events

Closes https://github.com/logstash-plugins/logstash-input-http/issues/157
