### PR TITLE
Update netty version to fix GHSA-5jpm-x58v-624v

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version rootProject.file('VERSION').text.trim()
 description = "HTTP Input Netty implementation"
 
 String log4jVersion = '2.17.0'
-String nettyVersion = '4.1.100.Final'
+String nettyVersion = '4.1.108.Final'
 String junitVersion = '5.9.2'
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
The version of netty you are using is affected with a CVE GHSA-5jpm-x58v-624v
Updating its version hoping the CVE will get fix for this.