### PR TITLE
Fix flaky assertion bound in testThreadSafetyBruteForce

### DIFF
--- a/src/test/java/org/logstash/plugins/inputs/http/util/ExecutionObserverTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/ExecutionObserverTest.java
@@ -191,7 +191,7 @@ class ExecutionObserverTest {
             assertThat(maxConcurrency.get(), is(greaterThan(1)));
             assertThat(maxNodes.get(), is(lessThanOrEqualTo(concurrency * 2)));
 
-            // without queries, we should at least have some compaction
+            // without queries, we may have some compaction so we shouldn't be too strict
             final ExecutionObserver.Stats preCompactionStats = observer.stats();
             assertThat(preCompactionStats.executing, is(0));
             assertThat(preCompactionStats.nodes, is(both(greaterThan(0)).and(lessThan(concurrency))));


### PR DESCRIPTION
Local compaction depends on completion order and timing. Under certain cases node count can reach or exceed `sqrt(concurrency)` before the final compaction is triggered. The test for intermediate state was failing fairly often in CI. This commit updates the test for intermediate state to simply be less than `concurrency`. This should satisfy the intent of the test, with the added security of the rest of the test asserting the finalized state is less than 2 nodes.

Closes https://github.com/logstash-plugins/logstash-input-http/issues/200
