### PR TITLE
Fix flaky 429 tests

### DIFF
--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -74,46 +74,37 @@ describe LogStash::Inputs::Http do
       let(:threads) { 1 }
       let(:logstash_queue) { SizedQueue.new(logstash_queue_size) }
       let(:client_options) { {
-        "request_timeout" => 1,
-        "connect_timeout" => 3,
-        "socket_timeout" => 0.2
+        request_timeout: 5,
+        connect_timeout: 3,
+        socket_timeout: 0.5
       } }
 
       let(:config) { { "port" => port, "threads" => threads, "max_pending_requests" => max_pending_requests } }
 
       context "when sending more requests than queue slots" do
         it "rejects additional incoming requests with HTTP 429" do
-          # these will queue and return 200
-          logstash_queue_size.times.each do |i|
+          # fill the pipeline queue so the next push blocks the server worker
+          logstash_queue_size.times do
             response = client.post("http://127.0.0.1:#{port}", :body => '{}').call
             expect(response.code).to eq(200)
           end
 
-          # these will block
-          blocked_calls = (threads + max_pending_requests).times.map do
-            Thread.new do
-              begin
-                {:result => client.post("http://127.0.0.1:#{port}", :body => '{}').call}
-              rescue Manticore::SocketException, Manticore::SocketTimeout => e
-                {:exception => e}
-              end
+          # a blocked request holds its slot even after the client times out, so sending
+          # sequentially fills every worker and backlog slot before the next 429
+          blocked = 0
+          response = nil
+          deadline = Time.now + 30
+          until response && response.code == 429
+            raise "server never returned 429 (blocked=#{blocked})" if Time.now > deadline
+            begin
+              response = client.post("http://127.0.0.1:#{port}", :body => '{}').call
+            rescue Manticore::SocketTimeout
+              blocked += 1
             end
           end
 
-          # wait for blocking requests to be in flight rather than using a fixed sleep
-          blocked_calls.each { |t| Thread.pass until t.status == 'sleep' || !t.alive? }
-
-          # by now we should be rejecting with 429 since the backlog is full
-          response = client.post("http://127.0.0.1:#{port}", :body => '{}').call
           expect(response.code).to eq(429)
-
-          # ensure that our blocked connections did block
-          aggregate_failures do
-            blocked_calls.map(&:value).each do |blocked|
-              expect(blocked[:result]).to be_nil
-              expect(blocked[:exception]).to be_a_kind_of Manticore::SocketTimeout
-            end
-          end
+          expect(blocked).to eq(threads + max_pending_requests)
         end
       end
     end

--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -69,14 +69,14 @@ describe LogStash::Inputs::Http do
     end
 
     describe "handling overflowing requests with a 429" do
-      let(:logstash_queue_size) { rand(10) + 1 }
-      let(:max_pending_requests) { rand(5) + 1 }
-      let(:threads) { rand(4) + 1 }
+      let(:logstash_queue_size) { 1 }
+      let(:max_pending_requests) { 1 }
+      let(:threads) { 1 }
       let(:logstash_queue) { SizedQueue.new(logstash_queue_size) }
       let(:client_options) { {
-        "request_timeout" => 0.1,
+        "request_timeout" => 1,
         "connect_timeout" => 3,
-        "socket_timeout" => 0.1
+        "socket_timeout" => 0.2
       } }
 
       let(:config) { { "port" => port, "threads" => threads, "max_pending_requests" => max_pending_requests } }
@@ -100,7 +100,8 @@ describe LogStash::Inputs::Http do
             end
           end
 
-          sleep 1 # let those requests go, but not so long that our block-detector starts emitting 429's
+          # wait for blocking requests to be in flight rather than using a fixed sleep
+          blocked_calls.each { |t| Thread.pass until t.status == 'sleep' || !t.alive? }
 
           # by now we should be rejecting with 429 since the backlog is full
           response = client.post("http://127.0.0.1:#{port}", :body => '{}').call
@@ -118,14 +119,14 @@ describe LogStash::Inputs::Http do
     end
 
     describe "observing queue back-pressure" do
-      let(:logstash_queue_size) { rand(10) + 1 }
-      let(:max_pending_requests) { rand(5) + 1 }
-      let(:threads) { rand(4) + 1 }
+      let(:logstash_queue_size) { 1 }
+      let(:max_pending_requests) { 1 }
+      let(:threads) { 1 }
       let(:logstash_queue) { SizedQueue.new(logstash_queue_size) }
       let(:client_options) { {
-        "request_timeout" => 0.1,
+        "request_timeout" => 1,
         "connect_timeout" => 3,
-        "socket_timeout" => 0.1
+        "socket_timeout" => 0.2
       } }
 
       let(:config) { { "port" => port, "threads" => threads, "max_pending_requests" => max_pending_requests } }
@@ -147,14 +148,17 @@ describe LogStash::Inputs::Http do
               end
             end
 
-          sleep 12 # let that requests go, and ensure it is blocking long enough to be problematic
+          # wait for blocking request to be in flight, then wait for the
+          # RejectWhenBlockedInboundHandler threshold (10s) to trigger
+          Thread.pass until blocked_call.status == 'sleep' || !blocked_call.alive?
+          sleep 11
 
           # by now we should be rejecting with 429 since at least one existing request is blocked
-          # for more than 10s.
+          # for more than 10s
           response = client.post("http://127.0.0.1:#{port}", :body => '{}').call
           expect(response.code).to eq(429)
 
-          # ensure that our blocked connections did block
+          # ensure that our blocked connection did block
           aggregate_failures do
             blocked_call.value.tap do |blocked|
               expect(blocked[:result]).to be_nil

--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -119,14 +119,14 @@ describe LogStash::Inputs::Http do
     end
 
     describe "observing queue back-pressure" do
-      let(:logstash_queue_size) { 1 }
-      let(:max_pending_requests) { 1 }
-      let(:threads) { 1 }
+      let(:logstash_queue_size) { rand(10) + 1 }
+      let(:max_pending_requests) { rand(5) + 1 }
+      let(:threads) { rand(4) + 1 }
       let(:logstash_queue) { SizedQueue.new(logstash_queue_size) }
       let(:client_options) { {
-        "request_timeout" => 1,
+        "request_timeout" => 0.1,
         "connect_timeout" => 3,
-        "socket_timeout" => 0.2
+        "socket_timeout" => 0.1
       } }
 
       let(:config) { { "port" => port, "threads" => threads, "max_pending_requests" => max_pending_requests } }
@@ -148,17 +148,14 @@ describe LogStash::Inputs::Http do
               end
             end
 
-          # wait for blocking request to be in flight, then wait for the
-          # RejectWhenBlockedInboundHandler threshold (10s) to trigger
-          Thread.pass until blocked_call.status == 'sleep' || !blocked_call.alive?
-          sleep 11
+          sleep 12 # let that requests go, and ensure it is blocking long enough to be problematic
 
           # by now we should be rejecting with 429 since at least one existing request is blocked
-          # for more than 10s
+          # for more than 10s.
           response = client.post("http://127.0.0.1:#{port}", :body => '{}').call
           expect(response.code).to eq(429)
 
-          # ensure that our blocked connection did block
+          # ensure that our blocked connections did block
           aggregate_failures do
             blocked_call.value.tap do |blocked|
               expect(blocked[:result]).to be_nil

--- a/spec/inputs/http_spec.rb
+++ b/spec/inputs/http_spec.rb
@@ -115,9 +115,9 @@ describe LogStash::Inputs::Http do
       let(:threads) { rand(4) + 1 }
       let(:logstash_queue) { SizedQueue.new(logstash_queue_size) }
       let(:client_options) { {
-        "request_timeout" => 0.1,
-        "connect_timeout" => 3,
-        "socket_timeout" => 0.1
+        request_timeout: 5,
+        connect_timeout: 3,
+        socket_timeout: 1
       } }
 
       let(:config) { { "port" => port, "threads" => threads, "max_pending_requests" => max_pending_requests } }


### PR DESCRIPTION
## Summary

The HTTP 429 rate-limiting test ("rejects additional incoming requests with HTTP 429") is flaky across all CI stacks and branches due to race conditions in the test setup.

**Root cause:**
- `client_options` uses **string keys** (`"socket_timeout" =>`) but Manticore's constructor reads **symbol keys** (`:socket_timeout`). All timeout values silently fall back to the 10-second default. The intended 100ms socket timeout never took effect.
- `rand()` for `threads`, `max_pending_requests`, and `logstash_queue_size` produces non-deterministic values. Larger values require more concurrent blocking requests to arrive at the server within a tight window.
- `sleep 1` is a race condition. There is no guarantee that all blocking requests have reached the server and filled the executor pool + ArrayBlockingQueue within 1 second.

## Failed Test URLs

https://github.com/logstash-plugins/logstash-input-http/actions/runs/30991406140/job/92258164314
https://github.com/logstash-plugins/logstash-input-http/actions/runs/30894496793/job/91944063697