### PR TITLE
Add Netty handler to log HTTP wire traffic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ String nettyVersion = '4.1.136.Final'
 String junitVersion = '5.9.2'
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {
@@ -36,7 +36,9 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+    testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}:tests"
     testImplementation 'org.mockito:mockito-core:5.12.0'
+    testImplementation 'org.awaitility:awaitility:4.2.2'
 }
 
 test {

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -92,10 +92,10 @@ for the request's content-type is found in the `additional_codecs` setting.
 
 [id="plugins-{type}s-{plugin}-wire-logging"]
 ==== Enable wire logging
-This plugin logs all requests and responses passing through the socket after TLS decoding.
+This plugin could logs all requests and responses passing through the socket after TLS decoding.
 This functionality helps troubleshoot issues in the processing pipeline that standard 
 external traffic captures, such as `tcpdump`, cannot resolve.
-To dump received and sent payloads post-TLS decoding, enable debug logging 
+By default it's disabled, to dump received and sent payloads post-TLS decoding, enable debug logging 
 for `org.logstash.plugins.inputs.http.util.WireLogger`.
 Note: Payloads exceeding 4 KB are automatically truncated to prevent excessive log file growth.
 If you want to set a different limit, then in {ls} `config/jvm.options` configure a value for the system property `logstash.httpinput.wire.dump.size`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -98,6 +98,14 @@ external traffic captures, such as `tcpdump`, cannot resolve.
 To dump received and sent payloads post-TLS decoding, enable debug logging 
 for `org.logstash.plugins.inputs.http.util.WireLogger`.
 Note: Payloads exceeding 4 KB are automatically truncated to prevent excessive log file growth.
+If you want to set a different limit, then in {ls} `config/jvm.options` configure a value for the system property `logstash.httpinput.wire.dump.size`.
+
+[source,text]
+-----
+-Dlogstash.httpinput.wire.dump.size=512
+-----
+If you want to remove any limit, at the risk of polluting {ls} logs, set it to `0`.
+Admitted values are only integers greater or equals to 0.
 
 To enable it start {ls} in debug mode or configure the `config/log4j2.properties` to include:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -90,7 +90,7 @@ Values in `additional_codecs` are prioritized over those specified in the
 `codec` option. That is, the default `codec` is applied only if no codec
 for the request's content-type is found in the `additional_codecs` setting.
 
-[id="plugins-{type}s-{plugin}-wire-logggin"]
+[id="plugins-{type}s-{plugin}-wire-logging"]
 ==== Enable wire logging
 This plugin logs all requests and responses passing through the socket after TLS decoding.
 This functionality helps troubleshoot issues in the processing pipeline that standard 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -90,6 +90,25 @@ Values in `additional_codecs` are prioritized over those specified in the
 `codec` option. That is, the default `codec` is applied only if no codec
 for the request's content-type is found in the `additional_codecs` setting.
 
+[id="plugins-{type}s-{plugin}-wire-logggin"]
+==== Enable wire logging
+This plugin logs all requests and responses passing through the socket after TLS decoding.
+This functionality helps troubleshoot issues in the processing pipeline that standard 
+external traffic captures, such as `tcpdump`, cannot resolve.
+To dump received and sent payloads post-TLS decoding, enable debug logging 
+for `org.logstash.plugins.inputs.http.util.WireLogger`.
+Note: Payloads exceeding 4 KB are automatically truncated to prevent excessive log file growth.
+
+To enable it start {ls} in debug mode or configure the `config/log4j2.properties` to include:
+
+[source,text]
+-----
+logger.httpwire.name = org.logstash.plugins.inputs.http.util.WireLogger
+logger.httpwire.level = DEBUG
+-----
+
+WARNING: when this log is enabled the payload is dumped, so if contains secretes those are exposed in {ls} logs.
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Http Input Configuration Options
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -92,7 +92,7 @@ for the request's content-type is found in the `additional_codecs` setting.
 
 [id="plugins-{type}s-{plugin}-wire-logging"]
 ==== Enable wire logging
-This plugin could logs all requests and responses passing through the socket after TLS decoding.
+This plugin could log all requests and responses passing through the socket after TLS decoding.
 This functionality helps troubleshoot issues in the processing pipeline that standard 
 external traffic captures, such as `tcpdump`, cannot resolve.
 By default it's disabled, to dump received and sent payloads post-TLS decoding, enable debug logging 

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -176,6 +176,8 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
 
     validate_ssl_settings!
 
+    validate_dump_size_system_property!
+    
     if @user && @password
       token = Base64.strict_encode64("#{@user}:#{@password.value}")
       @auth_token = "Basic #{token}"
@@ -276,6 +278,12 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
       [http_host, nil]
     end
   end
+  
+  def validate_dump_size_system_property!
+    java_import org.logstash.plugins.inputs.http.util.WireLogger
+    WireLogger.validate_dump_size_property
+  end
+  private :validate_dump_size_system_property!
 
   def validate_ssl_settings!
     ssl_config_name = original_params.include?('ssl') ? 'ssl' : 'ssl_enabled'

--- a/src/main/java/org/logstash/plugins/inputs/http/HttpInitializer.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/HttpInitializer.java
@@ -45,8 +45,8 @@ public class HttpInitializer extends ChannelInitializer<SocketChannel> {
             pipeline.addLast(sslHandler);
         }
 
-        pipeline.addLast(new HttpServerCodec());
         pipeline.addLast(new WireLogger());
+        pipeline.addLast(new HttpServerCodec());
         pipeline.addLast(new RejectWhenBlockedInboundHandler(executionObserver, Duration.ofSeconds(10)));
         pipeline.addLast(new HttpContentDecompressor());
         pipeline.addLast(new HttpObjectAggregator(maxContentLength));

--- a/src/main/java/org/logstash/plugins/inputs/http/HttpInitializer.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/HttpInitializer.java
@@ -12,6 +12,7 @@ import org.logstash.plugins.inputs.http.util.ExecutionObserver;
 import org.logstash.plugins.inputs.http.util.ExecutionObservingMessageHandler;
 import org.logstash.plugins.inputs.http.util.RejectWhenBlockedInboundHandler;
 import org.logstash.plugins.inputs.http.util.SslHandlerProvider;
+import org.logstash.plugins.inputs.http.util.WireLogger;
 
 import java.time.Duration;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -45,6 +46,7 @@ public class HttpInitializer extends ChannelInitializer<SocketChannel> {
         }
 
         pipeline.addLast(new HttpServerCodec());
+        pipeline.addLast(new WireLogger());
         pipeline.addLast(new RejectWhenBlockedInboundHandler(executionObserver, Duration.ofSeconds(10)));
         pipeline.addLast(new HttpContentDecompressor());
         pipeline.addLast(new HttpObjectAggregator(maxContentLength));

--- a/src/main/java/org/logstash/plugins/inputs/http/HttpInitializer.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/HttpInitializer.java
@@ -45,7 +45,9 @@ public class HttpInitializer extends ChannelInitializer<SocketChannel> {
             pipeline.addLast(sslHandler);
         }
 
-        pipeline.addLast(new WireLogger());
+        final int dumpSize = WireLogger.readDumpSizeProperty();
+
+        pipeline.addLast(new WireLogger(dumpSize));
         pipeline.addLast(new HttpServerCodec());
         pipeline.addLast(new RejectWhenBlockedInboundHandler(executionObserver, Duration.ofSeconds(10)));
         pipeline.addLast(new HttpContentDecompressor());

--- a/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
@@ -30,7 +30,7 @@ public class WireLogger extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
-            logger.debug("Read from {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
+            logger.debug("<< {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
         }
         ctx.fireChannelRead(msg);
     }
@@ -38,7 +38,7 @@ public class WireLogger extends ChannelDuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
-            logger.debug("Write to {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
+            logger.debug(">> {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
         }
         ctx.write(msg, promise);
     }

--- a/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
@@ -1,12 +1,13 @@
 package org.logstash.plugins.inputs.http.util;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class WireLogger extends ChannelInboundHandlerAdapter {
+public class WireLogger extends ChannelDuplexHandler {
 
     private final static Logger logger = LogManager.getLogger(WireLogger.class);
 
@@ -32,6 +33,14 @@ public class WireLogger extends ChannelInboundHandlerAdapter {
             logger.debug("Read from {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
         }
         ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
+            logger.debug("Write to {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
+        }
+        ctx.write(msg, promise);
     }
 
     private static String dump(ByteBuf buf) {

--- a/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
@@ -16,17 +16,33 @@ public class WireLogger extends ChannelDuplexHandler {
     private static final String SIZE_PROP_NAME = "logstash.httpinput.wire.dump.size";
     private final int maxDumpLength;
 
-    public static int readDumpSizeProperty() throws Exception {
+    /**
+     * Used to validate the dump's size system property. Has to be called before {@link #readDumpSizeProperty()}.
+     * 
+     * @throws RuntimeException if the number is not parseable as integer or if it's negative.
+     * */
+    public static void validateDumpSizeProperty() throws Exception {
         String dumpSizeStr = System.getProperty(SIZE_PROP_NAME, Integer.toString(MAX_DUMP_LENGTH));
         try {
             int dumpSize = Integer.parseInt(dumpSizeStr);
             if (dumpSize < 0) {
                 throw new RuntimeException(SIZE_PROP_NAME + " system property has received negative integer value: " + dumpSize);
             }
-            return dumpSize;
         } catch (NumberFormatException e) {
             throw new RuntimeException(SIZE_PROP_NAME + " system property has received invalid integer value: " + dumpSizeStr, e);
         }
+    }
+    
+    /**
+     * Method used to retrieve the dump's size system property value. 
+     * Doesn't check for validity, the {@link #validateDumpSizeProperty()} has to be called before.
+     * 
+     * @return integer value parsed from system property
+     * @throws Exception throw any error that Integer.parseInt encounter.
+     * */
+    public static int readDumpSizeProperty() throws Exception {
+        String dumpSizeStr = System.getProperty(SIZE_PROP_NAME, Integer.toString(MAX_DUMP_LENGTH));
+        return Integer.parseInt(dumpSizeStr);
     }
     
     public WireLogger(int maxDumpLength) {

--- a/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
@@ -1,0 +1,27 @@
+package org.logstash.plugins.inputs.http.util;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class WireLogger extends ChannelInboundHandlerAdapter {
+
+    private final static Logger logger = LogManager.getLogger(WireLogger.class);
+    
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Opening connection {}", ctx.channel().remoteAddress());
+        }
+        ctx.fireChannelActive();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Closing connection {}", ctx.channel().remoteAddress());
+        }
+        ctx.fireChannelInactive();
+    }
+}

--- a/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
@@ -1,5 +1,6 @@
 package org.logstash.plugins.inputs.http.util;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.apache.logging.log4j.LogManager;
@@ -8,7 +9,7 @@ import org.apache.logging.log4j.Logger;
 public class WireLogger extends ChannelInboundHandlerAdapter {
 
     private final static Logger logger = LogManager.getLogger(WireLogger.class);
-    
+
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         if (logger.isDebugEnabled()) {
@@ -23,5 +24,30 @@ public class WireLogger extends ChannelInboundHandlerAdapter {
             logger.debug("Closing connection {}", ctx.channel().remoteAddress());
         }
         ctx.fireChannelInactive();
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
+            logger.debug("Read from {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
+        }
+        ctx.fireChannelRead(msg);
+    }
+
+    private static String dump(ByteBuf buf) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = buf.readerIndex(), end = buf.readerIndex() + buf.readableBytes(); i < end; i++) {
+            byte b = buf.getByte(i);
+            if (b == '\r') {
+                sb.append("[\\r]");
+            } else if (b == '\n') {
+                sb.append("[\\n]");
+            } else if (b >= 0x20 && b < 0x7F) {
+                sb.append((char) b);
+            } else {
+                sb.append(String.format("[0x%02X]", b & 0xFF));
+            }
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
@@ -11,7 +11,27 @@ public class WireLogger extends ChannelDuplexHandler {
 
     private final static Logger logger = LogManager.getLogger(WireLogger.class);
 
-    static final int MAX_DUMP_LENGTH = 4096;
+    public static final int MAX_DUMP_LENGTH = 4096;
+    private static final int UNLIMITED_DUMP_LENGTH = 0;
+    private static final String SIZE_PROP_NAME = "logstash.httpinput.wire.dump.size";
+    private final int maxDumpLength;
+
+    public static int readDumpSizeProperty() throws Exception {
+        String dumpSizeStr = System.getProperty(SIZE_PROP_NAME, Integer.toString(MAX_DUMP_LENGTH));
+        try {
+            int dumpSize = Integer.parseInt(dumpSizeStr);
+            if (dumpSize < 0) {
+                throw new RuntimeException(SIZE_PROP_NAME + " system property has received negative integer value: " + dumpSize);
+            }
+            return dumpSize;
+        } catch (NumberFormatException e) {
+            throw new RuntimeException(SIZE_PROP_NAME + " system property has received invalid integer value: " + dumpSizeStr, e);
+        }
+    }
+    
+    public WireLogger(int maxDumpLength) {
+        this.maxDumpLength = maxDumpLength;
+    }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
@@ -32,7 +52,7 @@ public class WireLogger extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
-            logger.debug("<< {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg, MAX_DUMP_LENGTH));
+            logger.debug("<< {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg, maxDumpLength));
         }
         ctx.fireChannelRead(msg);
     }
@@ -40,7 +60,7 @@ public class WireLogger extends ChannelDuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
-            logger.debug(">> {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg, MAX_DUMP_LENGTH));
+            logger.debug(">> {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg, maxDumpLength));
         }
         ctx.write(msg, promise);
     }
@@ -48,10 +68,12 @@ public class WireLogger extends ChannelDuplexHandler {
     // maxLength == 0 means unlimited; any other value caps the dumped bytes and appends a truncation notice.
     static String dump(ByteBuf buf, int maxLength) {
         int total = buf.readableBytes();
-        int limit = (maxLength == 0) ? total : Math.min(maxLength, total);
+        int limit = (maxLength == UNLIMITED_DUMP_LENGTH) ? total : Math.min(maxLength, total);
 
         StringBuilder sb = new StringBuilder();
-        for (int i = buf.readerIndex(), end = buf.readerIndex() + limit; i < end; i++) {
+        final int start = buf.readerIndex();
+        final int end = start + limit;
+        for (int i = start; i < end; i++) {
             byte b = buf.getByte(i);
             if (b == '\r') {
                 sb.append("[\\r]");

--- a/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
+++ b/src/main/java/org/logstash/plugins/inputs/http/util/WireLogger.java
@@ -11,6 +11,8 @@ public class WireLogger extends ChannelDuplexHandler {
 
     private final static Logger logger = LogManager.getLogger(WireLogger.class);
 
+    static final int MAX_DUMP_LENGTH = 4096;
+
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         if (logger.isDebugEnabled()) {
@@ -30,7 +32,7 @@ public class WireLogger extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
-            logger.debug("<< {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
+            logger.debug("<< {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg, MAX_DUMP_LENGTH));
         }
         ctx.fireChannelRead(msg);
     }
@@ -38,14 +40,18 @@ public class WireLogger extends ChannelDuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (logger.isDebugEnabled() && msg instanceof ByteBuf) {
-            logger.debug(">> {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg));
+            logger.debug(">> {} : {}", ctx.channel().remoteAddress(), dump((ByteBuf) msg, MAX_DUMP_LENGTH));
         }
         ctx.write(msg, promise);
     }
 
-    private static String dump(ByteBuf buf) {
+    // maxLength == 0 means unlimited; any other value caps the dumped bytes and appends a truncation notice.
+    static String dump(ByteBuf buf, int maxLength) {
+        int total = buf.readableBytes();
+        int limit = (maxLength == 0) ? total : Math.min(maxLength, total);
+
         StringBuilder sb = new StringBuilder();
-        for (int i = buf.readerIndex(), end = buf.readerIndex() + buf.readableBytes(); i < end; i++) {
+        for (int i = buf.readerIndex(), end = buf.readerIndex() + limit; i < end; i++) {
             byte b = buf.getByte(i);
             if (b == '\r') {
                 sb.append("[\\r]");
@@ -57,6 +63,11 @@ public class WireLogger extends ChannelDuplexHandler {
                 sb.append(String.format("[0x%02X]", b & 0xFF));
             }
         }
+
+        if (maxLength > 0 && total > maxLength) {
+            sb.append("...[truncated, total ").append(total).append(" bytes]");
+        }
+
         return sb.toString();
     }
 }

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.matchesPattern;
 
@@ -105,8 +106,26 @@ class WireLoggerTest {
         client.close();
 
         List<String> messages = logSpy.getMessages();
-        assertThat(messages, hasItem(matchesPattern("Opening connection /" + HOST + ":\\d+")));
-        assertThat(messages, hasItem(matchesPattern("Closing connection /" + HOST + ":\\d+")));
+        assertThat(messages, hasItem(matchesPattern("Opening connection .*" + HOST + ":\\d+")));
+        assertThat(messages, hasItem(matchesPattern("Closing connection .*" + HOST + ":\\d+")));
+    }
+
+    @Test
+    void wireLoggerDumpsRawHttpRequestContent() throws Exception {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://" + HOST + ":" + port + "/"))
+                    .POST(HttpRequest.BodyPublishers.ofString("{\"message\": \"hello\"}"))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            client.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+
+        List<String> messages = logSpy.getMessages();
+        assertThat(messages, hasItem(matchesPattern("Read from .*" + HOST + ":\\d+ : POST.*")));
+        assertThat(messages, hasItem(containsString("[\\r][\\n]")));
+        assertThat(messages, hasItem(containsString("{\"message\": \"hello\"}")));
     }
 
     private void waitForServerReady() {

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -94,16 +94,16 @@ class WireLoggerTest {
 
     @Test
     void wireLoggerLogsOpeningAndClosingConnectionAroundHttpRequest() throws Exception {
-        HttpClient client = HttpClient.newHttpClient();
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("http://" + HOST + ":" + port + "/"))
-                .POST(HttpRequest.BodyPublishers.ofString("{\"message\": \"hello\"}"))
-                .header("Content-Type", "application/json")
-                .build();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://" + HOST + ":" + port + "/"))
+                    .POST(HttpRequest.BodyPublishers.ofString("{\"message\": \"hello\"}"))
+                    .header("Content-Type", "application/json")
+                    .build();
 
-        client.send(request, HttpResponse.BodyHandlers.ofString());
-        // Close client so that "Closing connection" is logged before we assert. 
-        client.close();
+            client.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        // Implicit close of auto-closeable client so that "Closing connection" is logged before we assert.
 
         List<String> messages = logSpy.getMessages();
         assertThat(messages, hasItem(matchesPattern("Opening connection .*" + HOST + ":\\d+")));
@@ -143,6 +143,24 @@ class WireLoggerTest {
         List<String> messages = logSpy.getMessages();
         assertThat(messages, hasItem(matchesPattern(">> .*" + HOST + ":\\d+ : HTTP/1\\.1 200 OK.*")));
         assertThat(messages, hasItem(containsString("[\\r][\\n]")));
+    }
+
+    @Test
+    void wireLoggerTruncatesRequestBiggerThanMaxDumpLength() throws Exception {
+        // Netty's AdaptiveRecvByteBufAllocator starts at 1024 bytes and jumps to 8192 after the
+        // first full read. With a body of MAX_DUMP_LENGTH * 3 bytes the second read chunk is
+        // 8192 > MAX_DUMP_LENGTH, which guarantees the truncation notice is appended.
+        String largeBody = "A".repeat(WireLogger.MAX_DUMP_LENGTH * 3);
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://" + HOST + ":" + port + "/"))
+                    .POST(HttpRequest.BodyPublishers.ofString(largeBody))
+                    .header("Content-Type", "application/json")
+                    .build(), HttpResponse.BodyHandlers.discarding());
+        }
+
+        assertThat(logSpy.getMessages(), hasItem(containsString("truncated, total")));
     }
 
     private void waitForServerReady() {

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -1,0 +1,136 @@
+package org.logstash.plugins.inputs.http.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.logstash.plugins.inputs.http.IMessageHandler;
+import org.logstash.plugins.inputs.http.NettyHttpServer;
+
+import org.awaitility.Awaitility;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.matchesPattern;
+
+class WireLoggerTest {
+
+    private static final String CONFIG = "log4j2-test-wirelogger.xml";
+
+    private static final String HOST = "127.0.0.1";
+
+    private NettyHttpServer server;
+    private int port;
+    private URI originalConfigUri;
+    private ListAppender logSpy;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        originalConfigUri = ctx.getConfigLocation();
+        ctx.setConfigLocation(getClass().getClassLoader().getResource(CONFIG).toURI());
+
+        port = findFreePort();
+
+        IMessageHandler noopHandler = new IMessageHandler() {
+            @Override
+            public boolean onNewMessage(String remoteAddress, Map<String, String> headers, String body) {
+                return true;
+            }
+
+            @Override
+            public boolean validatesToken(String token) {
+                return true;
+            }
+
+            @Override
+            public boolean requiresToken() {
+                return false;
+            }
+
+            @Override
+            public IMessageHandler copy() {
+                return this;
+            }
+
+            @Override
+            public Map<String, String> responseHeaders() {
+                return Collections.emptyMap();
+            }
+        };
+
+        server = new NettyHttpServer("test", HOST, port, noopHandler, null, 2, 100, 1024 * 1024, 200);
+        Thread serverThread = new Thread(server);
+        serverThread.setDaemon(true);
+        serverThread.setName("Test - NettyHttpServer runner");
+        serverThread.start();
+        waitForServerReady();
+
+        logSpy = getListAppender("WireLoggerList");
+        logSpy.clear();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.close();
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        ctx.setConfigLocation(originalConfigUri);
+    }
+
+    @Test
+    void wireLoggerLogsOpeningAndClosingConnectionAroundHttpRequest() throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://" + HOST + ":" + port + "/"))
+                .POST(HttpRequest.BodyPublishers.ofString("{\"message\": \"hello\"}"))
+                .header("Content-Type", "application/json")
+                .build();
+
+        client.send(request, HttpResponse.BodyHandlers.ofString());
+        // Close client so that "Closing connection" is logged before we assert. 
+        client.close();
+
+        List<String> messages = logSpy.getMessages();
+        assertThat(messages, hasItem(matchesPattern("Opening connection /" + HOST + ":\\d+")));
+        assertThat(messages, hasItem(matchesPattern("Closing connection /" + HOST + ":\\d+")));
+    }
+
+    private void waitForServerReady() {
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .until(this::checkServerReady);
+    }
+
+    private Boolean checkServerReady() {
+        try (Socket ignored = new Socket(HOST, port)) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+
+    private ListAppender getListAppender(String name) {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        return (ListAppender) ctx.getConfiguration().getAppender(name);
+    }
+}

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -128,6 +128,23 @@ class WireLoggerTest {
         assertThat(messages, hasItem(containsString("{\"message\": \"hello\"}")));
     }
 
+    @Test
+    void wireLoggerDumpsRawHttpResponseContent() throws Exception {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://" + HOST + ":" + port + "/"))
+                    .POST(HttpRequest.BodyPublishers.ofString("{\"message\": \"hello\"}"))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            client.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+
+        List<String> messages = logSpy.getMessages();
+        assertThat(messages, hasItem(matchesPattern("Write to .*" + HOST + ":\\d+ : HTTP/1\\.1 200 OK.*")));
+        assertThat(messages, hasItem(containsString("[\\r][\\n]")));
+    }
+
     private void waitForServerReady() {
         Awaitility.await()
                 .atMost(5, TimeUnit.SECONDS)

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -106,6 +106,10 @@ class WireLoggerTest {
         // Implicit close of auto-closeable client so that "Closing connection" is logged before we assert.
 
         List<String> messages = logSpy.getMessages();
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> messages.size() >= 4);
+        
         assertThat(messages, hasItem(matchesPattern("Opening connection .*" + HOST + ":\\d+")));
         assertThat(messages, hasItem(matchesPattern("Closing connection .*" + HOST + ":\\d+")));
     }

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -123,7 +123,7 @@ class WireLoggerTest {
         }
 
         List<String> messages = logSpy.getMessages();
-        assertThat(messages, hasItem(matchesPattern("Read from .*" + HOST + ":\\d+ : POST.*")));
+        assertThat(messages, hasItem(matchesPattern("<< .*" + HOST + ":\\d+ : POST.*")));
         assertThat(messages, hasItem(containsString("[\\r][\\n]")));
         assertThat(messages, hasItem(containsString("{\"message\": \"hello\"}")));
     }
@@ -141,7 +141,7 @@ class WireLoggerTest {
         }
 
         List<String> messages = logSpy.getMessages();
-        assertThat(messages, hasItem(matchesPattern("Write to .*" + HOST + ":\\d+ : HTTP/1\\.1 200 OK.*")));
+        assertThat(messages, hasItem(matchesPattern(">> .*" + HOST + ":\\d+ : HTTP/1\\.1 200 OK.*")));
         assertThat(messages, hasItem(containsString("[\\r][\\n]")));
     }
 

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -27,6 +27,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WireLoggerTest {
 
@@ -165,6 +167,48 @@ class WireLoggerTest {
         }
 
         assertThat(logSpy.getMessages(), hasItem(containsString("truncated, total")));
+    }
+
+    private static final String SIZE_PROP = "logstash.httpinput.wire.dump.size";
+
+    @Test
+    void readDumpSizePropertyReturnsPositiveValue() throws Exception {
+        System.setProperty(SIZE_PROP, "2048");
+        try {
+            assertEquals(2048, WireLogger.readDumpSizeProperty());
+        } finally {
+            System.clearProperty(SIZE_PROP);
+        }
+    }
+
+    @Test
+    void readDumpSizePropertyReturnsZeroForUnlimited() throws Exception {
+        System.setProperty(SIZE_PROP, "0");
+        try {
+            assertEquals(0, WireLogger.readDumpSizeProperty());
+        } finally {
+            System.clearProperty(SIZE_PROP);
+        }
+    }
+
+    @Test
+    void readDumpSizePropertyThrowsForNegativeValue() {
+        System.setProperty(SIZE_PROP, "-1");
+        try {
+            assertThrows(RuntimeException.class, WireLogger::readDumpSizeProperty);
+        } finally {
+            System.clearProperty(SIZE_PROP);
+        }
+    }
+
+    @Test
+    void readDumpSizePropertyThrowsForNonNumericValue() {
+        System.setProperty(SIZE_PROP, "notanumber");
+        try {
+            assertThrows(RuntimeException.class, WireLogger::readDumpSizeProperty);
+        } finally {
+            System.clearProperty(SIZE_PROP);
+        }
     }
 
     private void waitForServerReady() {

--- a/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
+++ b/src/test/java/org/logstash/plugins/inputs/http/util/WireLoggerTest.java
@@ -27,8 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.matchesPattern;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WireLoggerTest {
 
@@ -172,7 +171,7 @@ class WireLoggerTest {
     private static final String SIZE_PROP = "logstash.httpinput.wire.dump.size";
 
     @Test
-    void readDumpSizePropertyReturnsPositiveValue() throws Exception {
+    void readDumpSizePropertyReturnsTheConfiguredValueAsInteger() throws Exception {
         System.setProperty(SIZE_PROP, "2048");
         try {
             assertEquals(2048, WireLogger.readDumpSizeProperty());
@@ -182,30 +181,40 @@ class WireLoggerTest {
     }
 
     @Test
-    void readDumpSizePropertyReturnsZeroForUnlimited() throws Exception {
+    void validateDumpSizePropertyReturnsPositiveValue() throws Exception {
+        System.setProperty(SIZE_PROP, "2048");
+        try {
+            assertDoesNotThrow(WireLogger::validateDumpSizeProperty);
+        } finally {
+            System.clearProperty(SIZE_PROP);
+        }
+    }
+
+    @Test
+    void validateDumpSizePropertyForUnlimitedValue() {
         System.setProperty(SIZE_PROP, "0");
         try {
-            assertEquals(0, WireLogger.readDumpSizeProperty());
+            assertDoesNotThrow(WireLogger::validateDumpSizeProperty);
         } finally {
             System.clearProperty(SIZE_PROP);
         }
     }
 
     @Test
-    void readDumpSizePropertyThrowsForNegativeValue() {
+    void validateDumpSizePropertyThrowsForNegativeValue() {
         System.setProperty(SIZE_PROP, "-1");
         try {
-            assertThrows(RuntimeException.class, WireLogger::readDumpSizeProperty);
+            assertThrows(RuntimeException.class, WireLogger::validateDumpSizeProperty);
         } finally {
             System.clearProperty(SIZE_PROP);
         }
     }
 
     @Test
-    void readDumpSizePropertyThrowsForNonNumericValue() {
+    void validateDumpSizePropertyThrowsForNonNumericValue() {
         System.setProperty(SIZE_PROP, "notanumber");
         try {
-            assertThrows(RuntimeException.class, WireLogger::readDumpSizeProperty);
+            assertThrows(RuntimeException.class, WireLogger::validateDumpSizeProperty);
         } finally {
             System.clearProperty(SIZE_PROP);
         }

--- a/src/test/resources/log4j2-test-wirelogger.xml
+++ b/src/test/resources/log4j2-test-wirelogger.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Appenders>
+        <List name="WireLoggerList">
+            <PatternLayout pattern="%m"/>
+        </List>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.logstash.plugins.inputs.http.util.WireLogger" level="debug" additivity="false">
+            <AppenderRef ref="WireLoggerList"/>
+        </Logger>
+        <Root level="warn"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Implements a functionality to log HTTP traffic. It's enabled by enabling debug log.

## What does this PR do?

- Created new WireLogger Netty handler to log information about channel opening/closing and dumping read and write traffic.
- Truncate the dumped content to 4KB or can be customised by setting `logstash.httpinput.wire.dump.size` Java system property.
- Updated client channel initializer to include such handler.
- Updates Java target and source compatibility to use HttpClient provided by JDK standard library since version 11.


## Why is it important/What is the impact to the user?

As a user that want's to debug his data flow I need to be able to track what's effectively sent to the HTTP input socket.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
Run a Logstash pipeline which includes an HTTP input filter enabling the logger in `config/log4j2.properties` with:
```properties
logger.httpwire.name = org.logstash.plugins.inputs.http.util.WireLogger
logger.httpwire.level = DEBUG
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #236 

## Use cases

Given some issue with the messages received from an HTTP input I want to enable debug logging to check what's in transit on the TCP level, after the TLS layer.


## Logs

Produced logs for gzipped content:
```
[2026-08-18T09:16:07,087][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] Opening connection /127.0.0.1:50455
[2026-08-18T09:16:07,091][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] << /127.0.0.1:50455 : POST / HTTP/1.1[\r][\n]Content-Type: application/json[\r][\n]Content-Encoding: gzip[\r][\n]Accept-Encoding: gzip, x-gzip, deflate[\r][\n]Host: localhost:8080[\r][\n]Content-Length: 40[\r][\n]Connection: keep-alive[\r][\n]User-Agent: Apache-HttpClient/5.4.3 (Java/21.0.10)[\r][\n][\r][\n][0x1F][0x8B][0x08][0x00][0x00][0x00][0x00][0x00][0x00][0xFF][0xAB]V[0xCA]M-.NLOU[0xB2]RP[0xCA]H[0xCD][0xC9][0xC9]W[0xAA][0x05][0x00]![0xC3][0x0E][0x9F][0x14][0x00][0x00][0x00]
[2026-08-18T09:16:07,111][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] >> /127.0.0.1:50455 : HTTP/1.1 200 OK[\r][\n]content-length: 2[\r][\n]content-type: text/plain[\r][\n][\r][\n]ok
[2026-08-18T09:16:07,115][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] Closing connection /127.0.0.1:50455
```

Produced logs for plain content:
```
[2026-08-18T09:17:05,264][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] Opening connection /127.0.0.1:50466
[2026-08-18T09:17:05,266][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] << /127.0.0.1:50466 : POST / HTTP/1.1[\r][\n]Content-Type: application/json[\r][\n]Accept-Encoding: gzip, x-gzip, deflate[\r][\n]Host: localhost:8080[\r][\n]Content-Length: 20[\r][\n]Connection: keep-alive[\r][\n]User-Agent: Apache-HttpClient/5.4.3 (Java/21.0.10)[\r][\n][\r][\n]{"message": "hello"}
[2026-08-18T09:17:05,633][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] >> /127.0.0.1:50466 : HTTP/1.1 200 OK[\r][\n]content-length: 2[\r][\n]content-type: text/plain[\r][\n][\r][\n]ok
[2026-08-18T09:17:05,641][DEBUG][org.logstash.plugins.inputs.http.util.WireLogger][main] Closing connection /127.0.0.1:50466
```


